### PR TITLE
Task error handler

### DIFF
--- a/src/main/java/school/faang/bjs246318/ErrorHandler.java
+++ b/src/main/java/school/faang/bjs246318/ErrorHandler.java
@@ -1,0 +1,11 @@
+package school.faang.bjs246318;
+
+public class ErrorHandler {
+    public static <T> T withErrorHandling(SupplierWithException<T> action, ExceptionHandler<T> exceptionHandler) {
+        try {
+            return action.get();
+        } catch (Exception e) {
+            return exceptionHandler.handle(e);
+        }
+    }
+}

--- a/src/main/java/school/faang/bjs246318/ExceptionHandler.java
+++ b/src/main/java/school/faang/bjs246318/ExceptionHandler.java
@@ -1,0 +1,6 @@
+package school.faang.bjs246318;
+
+@FunctionalInterface
+public interface ExceptionHandler<T> {
+    T handle(Exception e);
+}

--- a/src/main/java/school/faang/bjs246318/Main.java
+++ b/src/main/java/school/faang/bjs246318/Main.java
@@ -1,0 +1,13 @@
+package school.faang.bjs246318;
+
+public class Main {
+    public static void main(String[] args) {
+        String requestOnRemoteService =
+                ErrorHandler.withErrorHandling(() -> RemoteService.calls("Very important parameters"),
+                        e -> {
+                            System.out.println(e.getMessage());
+                            return "Default answer";
+                        });
+        System.out.println(requestOnRemoteService);
+    }
+}

--- a/src/main/java/school/faang/bjs246318/RemoteService.java
+++ b/src/main/java/school/faang/bjs246318/RemoteService.java
@@ -1,0 +1,14 @@
+package school.faang.bjs246318;
+
+import java.util.Objects;
+
+public class RemoteService {
+    public static String calls(String parameters) throws Exception {
+        if (Objects.equals(parameters, "Very important parameters")) {
+            String answer = "Response remote service: The request was successfully processed, returning result.";
+            return answer;
+        } else {
+            throw new Exception("Remote service unavailable!");
+        }
+    }
+}

--- a/src/main/java/school/faang/bjs246318/SupplierWithException.java
+++ b/src/main/java/school/faang/bjs246318/SupplierWithException.java
@@ -1,0 +1,6 @@
+package school.faang.bjs246318;
+
+@FunctionalInterface
+public interface SupplierWithException<T> {
+    T get() throws Exception;
+}


### PR DESCRIPTION
Можно было не создавать свой Supplier для основного действия, но стандартный Supplier не обрабатывает проверяемые исключения, поэтому пришлось сделать так. Но если использовать RunTimeException, то тогда можно обойтись стандартным Supplier. Но по условию задачи вторая лямбда принимает объект Exception.