### PR TITLE
facebookleavingacomment bjs2 75986

### DIFF
--- a/src/main/java/school/faang/stream4/facebookleavingacomment/Comment.java
+++ b/src/main/java/school/faang/stream4/facebookleavingacomment/Comment.java
@@ -1,0 +1,14 @@
+package school.faang.stream4.facebookleavingacomment;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Getter
+public class Comment {
+    private final String text;
+    private final String author;
+    private final LocalDateTime timeStamp;
+}

--- a/src/main/java/school/faang/stream4/facebookleavingacomment/Main.java
+++ b/src/main/java/school/faang/stream4/facebookleavingacomment/Main.java
@@ -1,0 +1,7 @@
+package school.faang.stream4.facebookleavingacomment;
+
+public class Main {
+    public static void main(String[] args) {
+
+    }
+}

--- a/src/main/java/school/faang/stream4/facebookleavingacomment/Main.java
+++ b/src/main/java/school/faang/stream4/facebookleavingacomment/Main.java
@@ -1,7 +1,74 @@
 package school.faang.stream4.facebookleavingacomment;
 
+import java.time.LocalDateTime;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
 public class Main {
     public static void main(String[] args) {
+        PostService postService = new PostService();
 
+        Post post1 = new Post(1, "Пост 1", "Это первый пост", "Автор1");
+        Post post2 = new Post(2, "Пост 2", "Это второй пост", "Автор2");
+        Post post3 = new Post(3, "Пост 3", "Это третий пост", "Автор1");
+
+        Comment comment1 = new Comment("Это комментарий к первому посту", "Автор3", LocalDateTime.now());
+        Comment comment2 = new Comment("Это комментарий к второму посту", "Автор1", LocalDateTime.now());
+        Comment comment3 = new Comment("Это комментарий к второму посту", "Автор3", LocalDateTime.now());
+
+        ExecutorService pool = Executors.newCachedThreadPool();
+
+        CompletableFuture.runAsync(() -> postService.addPost(post1), pool).join();
+        CompletableFuture.runAsync(() -> postService.addPost(post2), pool).join();
+        CompletableFuture.runAsync(() -> postService.addPost(post3), pool).join();
+
+        postService.addComment(1, comment1).join();
+        postService.addComment(2, comment2).join();
+        postService.addComment(2, comment3).join();
+
+        postService.showPostsOfThisAuthor("Автор1")
+                .thenAccept(posts -> {
+                    System.out.println("Посты автора 'Автор1':");
+                    posts.forEach(post -> System.out.println(post.getContent()));
+                }).join();
+
+        postService.showCommentsToPostByPostId(1)
+                .thenAccept(comments -> {
+                    System.out.println("Комментарии к первому посту:");
+                    comments.forEach(comment -> System.out.println(comment.getText()));
+                }).join();
+
+        postService.removeCommentByItsAuthorByTimeStamp(1, "Автор3", comment1.getTimeStamp())
+                .thenRun(() -> {
+                    postService.showCommentsToPostByPostId(1)
+                            .thenAccept(comments -> {
+                                System.out.println("Комментарии к первому посту после удаления:");
+                                comments.forEach(comment -> System.out.println(comment.getText()));
+                            }).join();
+                })
+                .join();
+
+        postService.removePostByPostIdByItsAuthor(2, "Автор2")
+                .thenRun(() -> {
+                    postService.showPostsOfThisAuthor("Автор2")
+                            .thenAccept(posts -> {
+                                System.out.println("Посты автора 'Автор2' после удаления поста:");
+                                posts.forEach(post -> System.out.println(post.getContent()));
+                            }).join();
+                })
+                .join();
+
+        pool.shutdown();
+
+        try {
+            if (!pool.awaitTermination(1000, TimeUnit.MILLISECONDS)) {
+                pool.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            System.out.println(e + " - завершение пула потоков прервано");
+            pool.shutdownNow();
+        }
     }
 }

--- a/src/main/java/school/faang/stream4/facebookleavingacomment/Post.java
+++ b/src/main/java/school/faang/stream4/facebookleavingacomment/Post.java
@@ -1,0 +1,21 @@
+package school.faang.stream4.facebookleavingacomment;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Getter
+public class Post {
+    private final int id;
+    private final String title;
+    private final String content;
+    private final String author;
+    private List<Comment> comments = new ArrayList<>();
+
+    public synchronized void addComment(Comment comment) {
+        comments.add(comment);
+    }
+}

--- a/src/main/java/school/faang/stream4/facebookleavingacomment/PostService.java
+++ b/src/main/java/school/faang/stream4/facebookleavingacomment/PostService.java
@@ -1,0 +1,88 @@
+package school.faang.stream4.facebookleavingacomment;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Slf4j
+public class PostService {
+    @Getter
+    private final ConcurrentHashMap<Integer, Post> posts = new ConcurrentHashMap<>();
+    private final Lock lock = new ReentrantLock();
+
+    public CompletableFuture<Void> addPost(Post post) {
+        return CompletableFuture.runAsync(() -> posts.put(post.getId(), post));
+    }
+
+    public CompletableFuture<Void> addComment(int postId, Comment comment) {
+        return CompletableFuture.runAsync(() -> {
+            lock.lock();
+            try {
+                posts.get(postId).addComment(comment);
+            } catch (NullPointerException e) {
+                log.error("Такого поста не существует", e);
+            } finally {
+                lock.unlock();
+            }
+        });
+    }
+
+    public CompletableFuture<List<Post>> showPostsOfThisAuthor(String author) {
+        return CompletableFuture.supplyAsync(() -> {
+            ConcurrentHashMap<Integer, Post> postsCopy = this.getPosts();
+            return postsCopy.values().stream()
+                    .filter(post -> Objects.equals(post.getAuthor(), author))
+                    .toList();
+        });
+    }
+
+    public CompletableFuture<List<Comment>> showCommentsToPostByPostId(int postId) {
+        return CompletableFuture.supplyAsync(() -> {
+            lock.lock();
+            try {
+                return posts.get(postId).getComments();
+            } catch (NullPointerException e) {
+                log.error("Такого поста не существует", e);
+                return Collections.emptyList();
+            } finally {
+                lock.unlock();
+            }
+        });
+    }
+
+    public CompletableFuture<Void> removePostByPostIdByItsAuthor(int postId, String author) {
+        return CompletableFuture.runAsync(() -> {
+            Post post = posts.get(postId);
+            if (post != null && Objects.equals(post.getAuthor(), author)) {
+                posts.remove(postId);
+            }
+        });
+    }
+
+    public CompletableFuture<Void> removeCommentByItsAuthorByTimeStamp(int postId,
+                                                                       String author, LocalDateTime timeStamp) {
+        return CompletableFuture.runAsync(() -> {
+            lock.lock();
+            try {
+                Post post = posts.get(postId);
+                if (post != null) {
+                    List<Comment> comments = post.getComments();
+                    comments.removeIf(comment ->
+                            Objects.equals(comment.getAuthor(), author)
+                                    && comment.getTimeStamp().equals(timeStamp)
+                    );
+                }
+            } finally {
+                lock.unlock();
+            }
+        });
+    }
+}


### PR DESCRIPTION
Во избежание Lock contention, если я его правильно поняла, я ReentrantLock использовала для перебора списка комментариев к посту только, а сами посты в ConcurrentHashMap сложила, чтобы действия с каждым из них (или, по крайней мере, с попавшими в разные бакеты) происходили параллельно; и делала копию Мапы в методе showPostsOfThisAuthor, чтобы не занимать её на время работы этого метода (кстати, это вообще полезно или блокировка на время копирования не лучше блокировки на время работы самого метода?)
Но, честно говоря, не очень понимаю, ReentrantLock - лучший ли вариант для обращений к спискам комментов? Его надо было по условию задачи использовать. Но он же один на все посты (и списки их комментариев). Может, здесь какая-то другая синхронизация предпочтительней?